### PR TITLE
Point site to allanvrealestate.com, add CNAME, and reduce mobile CTA noise

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+allanvrealestate.com

--- a/DEPLOYMENT_AUTOMATION.md
+++ b/DEPLOYMENT_AUTOMATION.md
@@ -18,7 +18,7 @@ This repo now includes a GitHub Actions workflow that auto-deploys your static s
 2. Commit.
 3. Push to `work`.
 4. Wait ~1–3 minutes for the Actions run to complete.
-5. Refresh https://allan939.github.io/newconsguide/
+5. Refresh https://allanvrealestate.com/
 
 ## Notes
 - If deployment fails, check **Actions** tab logs in GitHub.

--- a/index.html
+++ b/index.html
@@ -8,12 +8,12 @@
 <meta property="og:description" content="Exclusive builder deals, live market stats, and expert guidance on new construction homes in Houston, TX. I work alongside top builders to find the best deals for buyers.">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Allan Vega · Houston New Construction">
-<meta property="og:url" content="https://allan939.github.io/newconsguide/">
-<meta property="og:image" content="https://allan939.github.io/newconsguide/allan-vega.jpg">
+<meta property="og:url" content="https://allanvrealestate.com/">
+<meta property="og:image" content="https://allanvrealestate.com/allan-vega.jpg">
 <meta property="og:image:alt" content="Allan Vega, Houston new construction specialist">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://allan939.github.io/newconsguide/allan-vega.jpg">
-<link rel="canonical" href="https://allan939.github.io/newconsguide/">
+<meta name="twitter:image" content="https://allanvrealestate.com/allan-vega.jpg">
+<link rel="canonical" href="https://allanvrealestate.com/">
 <meta name="twitter:title" content="Houston New Construction Homes | Allan Vega">
 <meta name="twitter:description" content="Exclusive builder deals, live market stats, and expert guidance on new construction homes in Houston, TX.">
 
@@ -381,6 +381,11 @@ footer{padding:44px 52px;background:var(--brown);display:flex;align-items:center
 .scta-close{position:absolute;top:50%;right:14px;transform:translateY(-50%);background:none;border:none;color:rgba(245,239,228,0.35);font-size:1.5rem;cursor:pointer;line-height:1;padding:6px 8px;transition:color 0.2s;}
 .scta-close:hover{color:#F5EFE4;}
 @media(max-width:768px){
+  /* Mobile cleanup: keep one persistent CTA (call bar) to reduce clutter/lag */
+  #sticky-cta-bar,.sms-float,.nav-links .nav-cta-mobile,.hero-ctas .btn-outline{display:none!important;}
+  #exit-popup{display:none!important;}
+  body::before{display:none;}
+  nav,.nav-links{backdrop-filter:none;-webkit-backdrop-filter:none;}
   .scta-inner{flex-direction:column;padding:14px 16px 18px;gap:12px;align-items:stretch;}
   .scta-copy{text-align:center;}
   .scta-headline{white-space:normal;font-size:0.95rem;}
@@ -388,7 +393,7 @@ footer{padding:44px 52px;background:var(--brown);display:flex;align-items:center
   .scta-submit{width:100%;padding:14px;}
   .scta-success{justify-content:center;}
   .scta-close{top:12px;right:10px;transform:none;}
-  body.scta-active .sticky-call{display:none;}
+  body.scta-active .sticky-call{display:block;}
   /* Hide SMS float when CTA bar is open — prevents overlap */
   body.scta-active .sms-float{display:none;}
   /* Safe-area inset for notched iPhones */
@@ -637,7 +642,7 @@ footer{padding:44px 52px;background:var(--brown);display:flex;align-items:center
   "name": "Allan Vega",
   "jobTitle": "New Construction Specialist",
   "telephone": "+12818657146",
-  "url": "https://allan939.github.io/newconsguide/",
+  "url": "https://allanvrealestate.com/",
   "address": {
     "@type": "PostalAddress",
     "addressLocality": "Houston",
@@ -1579,10 +1584,11 @@ document.querySelectorAll('.faq-q').forEach(function(btn) {
   });
 });
 
-// Sticky CTA Bar — slides up after 400px scroll, dismissible for session
+// Sticky CTA Bar — desktop/tablet only; dismissible for session
 (function() {
   var bar = document.getElementById('sticky-cta-bar');
   if (!bar) return;
+  if (window.matchMedia && window.matchMedia('(max-width: 768px)').matches) return;
   var STORAGE_KEY = 'scta_dismissed';
   if (sessionStorage.getItem(STORAGE_KEY)) return;
   var shown = false;
@@ -1643,10 +1649,11 @@ function submitStickyCTA(e) {
     });
 }
 
-// Exit-intent popup (desktop: fires on mouse leaving viewport top; mobile: fires on 60% scroll)
+// Exit-intent popup (desktop only to reduce mobile CTA noise/perf)
 (function() {
   var popup = document.getElementById('exit-popup');
   if (!popup) return;
+  if (window.matchMedia && window.matchMedia('(max-width: 768px)').matches) return;
   var shown = false;
   var STORAGE_KEY = 'exit_popup_shown';
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://allan939.github.io/newconsguide/sitemap.xml
+Sitemap: https://allanvrealestate.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://allan939.github.io/newconsguide/</loc>
+    <loc>https://allanvrealestate.com/</loc>
     <lastmod>2026-04-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://allan939.github.io/newconsguide/blog-houston-new-construction-2026.html</loc>
+    <loc>https://allanvrealestate.com/blog-houston-new-construction-2026.html</loc>
     <lastmod>2026-04-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://allan939.github.io/newconsguide/blog-katy-vs-cypress-new-construction.html</loc>
+    <loc>https://allanvrealestate.com/blog-katy-vs-cypress-new-construction.html</loc>
     <lastmod>2026-04-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://allan939.github.io/newconsguide/blog-builder-incentives-houston.html</loc>
+    <loc>https://allanvrealestate.com/blog-builder-incentives-houston.html</loc>
     <lastmod>2026-04-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/template.html
+++ b/template.html
@@ -8,11 +8,11 @@
 <meta property="og:description" content="Exclusive builder deals, live market stats, and expert guidance on new construction homes in Houston, TX. I work alongside top builders to find the best deals for buyers.">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Allan Vega · Houston New Construction">
-<meta property="og:url" content="https://allan939.github.io/newconsguide/">
-<meta property="og:image" content="https://allan939.github.io/newconsguide/og-image.jpg">
+<meta property="og:url" content="https://allanvrealestate.com/">
+<meta property="og:image" content="https://allanvrealestate.com/og-image.jpg">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="https://allan939.github.io/newconsguide/og-image.jpg">
-<link rel="canonical" href="https://allan939.github.io/newconsguide/">
+<meta name="twitter:image" content="https://allanvrealestate.com/og-image.jpg">
+<link rel="canonical" href="https://allanvrealestate.com/">
 <meta name="twitter:title" content="Houston New Construction Homes | Allan Vega">
 <meta name="twitter:description" content="Exclusive builder deals, live market stats, and expert guidance on new construction homes in Houston, TX.">
 
@@ -356,6 +356,11 @@ footer{padding:44px 52px;background:var(--brown);display:flex;align-items:center
 .scta-close{position:absolute;top:50%;right:14px;transform:translateY(-50%);background:none;border:none;color:rgba(245,239,228,0.35);font-size:1.5rem;cursor:pointer;line-height:1;padding:6px 8px;transition:color 0.2s;}
 .scta-close:hover{color:#F5EFE4;}
 @media(max-width:768px){
+  /* Mobile cleanup: keep one persistent CTA (call bar) to reduce clutter/lag */
+  #sticky-cta-bar,.sms-float,.nav-links .nav-cta-mobile,.hero-ctas .btn-outline{display:none!important;}
+  #exit-popup{display:none!important;}
+  body::before{display:none;}
+  nav,.nav-links{backdrop-filter:none;-webkit-backdrop-filter:none;}
   .scta-inner{flex-direction:column;padding:14px 16px 18px;gap:12px;align-items:stretch;}
   .scta-copy{text-align:center;}
   .scta-headline{white-space:normal;font-size:0.95rem;}
@@ -363,7 +368,7 @@ footer{padding:44px 52px;background:var(--brown);display:flex;align-items:center
   .scta-submit{width:100%;padding:14px;}
   .scta-success{justify-content:center;}
   .scta-close{top:12px;right:10px;transform:none;}
-  body.scta-active .sticky-call{display:none;}
+  body.scta-active .sticky-call{display:block;}
   /* Hide SMS float when CTA bar is open — prevents overlap */
   body.scta-active .sms-float{display:none;}
   /* Safe-area inset for notched iPhones */
@@ -607,7 +612,7 @@ footer{padding:44px 52px;background:var(--brown);display:flex;align-items:center
   "name": "Allan Vega",
   "jobTitle": "New Construction Specialist",
   "telephone": "+12818657146",
-  "url": "https://allan939.github.io/newconsguide/",
+  "url": "https://allanvrealestate.com/",
   "address": {
     "@type": "PostalAddress",
     "addressLocality": "Houston",
@@ -1456,10 +1461,11 @@ document.querySelectorAll('.faq-q').forEach(function(btn) {
   });
 });
 
-// Sticky CTA Bar — slides up after 400px scroll, dismissible for session
+// Sticky CTA Bar — desktop/tablet only; dismissible for session
 (function() {
   var bar = document.getElementById('sticky-cta-bar');
   if (!bar) return;
+  if (window.matchMedia && window.matchMedia('(max-width: 768px)').matches) return;
   var STORAGE_KEY = 'scta_dismissed';
   if (sessionStorage.getItem(STORAGE_KEY)) return;
   var shown = false;
@@ -1515,10 +1521,11 @@ function submitStickyCTA(e) {
     });
 }
 
-// Exit-intent popup (desktop: fires on mouse leaving viewport top; mobile: fires on 60% scroll)
+// Exit-intent popup (desktop only to reduce mobile CTA noise/perf)
 (function() {
   var popup = document.getElementById('exit-popup');
   if (!popup) return;
+  if (window.matchMedia && window.matchMedia('(max-width: 768px)').matches) return;
   var shown = false;
   var STORAGE_KEY = 'exit_popup_shown';
 


### PR DESCRIPTION
### Motivation
- Move the static site from the GitHub Pages URL to the custom domain `allanvrealestate.com` and update deployment documentation accordingly. 
- Ensure crawlers and sitemaps reflect the new canonical domain. 
- Reduce mobile clutter and improve perceived performance by disabling overlapping CTAs and exit popups on small screens.

### Description
- Added a `CNAME` file containing `allanvrealestate.com` and updated `DEPLOYMENT_AUTOMATION.md` to reference the new domain and live URL. 
- Replaced GitHub Pages references with the new domain in `index.html`, `template.html`, `robots.txt`, and `sitemap.xml` (meta tags: `og:url`, `og:image`, `twitter:image`, and `link rel="canonical"`, plus sitemap `loc` entries and `robots.txt` sitemap). 
- Updated CSS to hide the sticky CTA, SMS float, mobile CTAs, and `#exit-popup` on viewports `max-width: 768px`, and adjusted some mobile layout and safe-area rules. 
- Added JavaScript guards so the sticky CTA and exit-intent popup logic short-circuit on small screens using `window.matchMedia('(max-width: 768px)')`. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48652187c83299589fa4067f22313)